### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/src/nodes/SurrealDb/resources/query/operations/buildSelectQuery.operation.ts
+++ b/src/nodes/SurrealDb/resources/query/operations/buildSelectQuery.operation.ts
@@ -81,7 +81,7 @@ function buildWhereClause(conditions: WhereCondition[]): string {
                     clause += ` ${trimmedValue}`;
                 } else {
                     // Treat as string, wrap in quotes
-                    clause += ` '${condition.value.replace(/'/g, "\\'")}'`;
+                    clause += ` '${condition.value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
                 }
             }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/surrealdb/n8n-nodes-surrealdb/security/code-scanning/3](https://github.com/surrealdb/n8n-nodes-surrealdb/security/code-scanning/3)

To fix the problem, we need to ensure that both backslashes and single quotes are properly escaped in string values. The correct order is to first escape all backslashes (`\` → `\\`), then escape all single quotes (`'` → `\'`). This prevents any backslashes that precede a quote from interfering with the escaping of the quote itself. The fix should be applied only to the line where the escaping is performed, i.e., line 84 in the `buildWhereClause` function. No new methods are needed, but the replacement should use two chained `.replace()` calls or a single replace with a callback, and no additional imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
